### PR TITLE
Custom Properties Support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.0.1.{build}
+version: 1.1.0.{build}
 pull_requests:
   do_not_increment_build_number: true
 branches:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogworks.Meganav",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "url": "https://github.com/thecogworks/meganav",
   "license": {
     "name": "MIT",

--- a/src/Cogworks.Meganav/Cogworks.Meganav.csproj
+++ b/src/Cogworks.Meganav/Cogworks.Meganav.csproj
@@ -31,6 +31,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Constants.cs" />
+    <Compile Include="Converters\DictionaryConverter.cs" />
     <Compile Include="Enums\MeganavItem.cs" />
     <Compile Include="Models\MeganavItem.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -284,7 +285,10 @@
     <None Include="Web\UI\App_Plugins\Meganav\Js\meganavSettings.controller.js" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Web\UI\Views\" />
+    <None Include="Web\UI\App_Plugins\Meganav\Views\prevalues.html" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Web\UI\App_Plugins\Meganav\Js\meganavPrevalue.controller.js" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\AutoMapper.3.3.1\tools\AutoMapper.targets" Condition="Exists('..\packages\AutoMapper.3.3.1\tools\AutoMapper.targets')" />

--- a/src/Cogworks.Meganav/Converters/DictionaryConverter.cs
+++ b/src/Cogworks.Meganav/Converters/DictionaryConverter.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Cogworks.Meganav.Converters
+{
+    public class DictionaryConverter : JsonConverter
+    {
+        public override object ReadJson(
+            JsonReader reader,
+            Type objectType,
+            object existingValue,
+            JsonSerializer serializer
+        )
+        {
+            IDictionary<string, object> result;
+
+            if ( reader.TokenType == JsonToken.StartArray )
+            {
+                var legacyArray = ( JArray ) JToken.ReadFrom( reader );
+
+                result = legacyArray.ToDictionary(
+                    el => el[ "Key" ].ToString(),
+                    el => ( object ) el[ "Value" ] );
+            }
+            else
+            {
+                result =
+                    ( IDictionary<string, object> )
+                    serializer.Deserialize( reader, typeof( IDictionary<string, object> ) );
+            }
+
+            return result;
+        }
+
+        public override bool CanConvert( Type objectType )
+        {
+            return typeof( IDictionary<string, object> ).IsAssignableFrom( objectType );
+        }
+
+        public override bool CanWrite
+        {
+            get { return false; }
+        }
+
+        public override void WriteJson( JsonWriter writer, object value, JsonSerializer serializer )
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Cogworks.Meganav/Models/MeganavItem.cs
+++ b/src/Cogworks.Meganav/Models/MeganavItem.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Cogworks.Meganav.Converters;
 using Cogworks.Meganav.Enums;
 using Newtonsoft.Json;
 using Umbraco.Core.Models;
@@ -17,6 +18,9 @@ namespace Cogworks.Meganav.Models
 
         [JsonIgnore]
         public IPublishedContent Content { get; set; }
+
+        [JsonConverter( typeof( DictionaryConverter ) )]
+        public IDictionary<string, object> Properties { get; set; }
 
         #region Internal
 

--- a/src/Cogworks.Meganav/Properties/AssemblyInfo.cs
+++ b/src/Cogworks.Meganav/Properties/AssemblyInfo.cs
@@ -2,7 +2,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cogworks.Meganav")]
@@ -14,8 +14,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -25,12 +25,12 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.1.0")]
-[assembly: AssemblyFileVersion("1.0.1.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/src/Cogworks.Meganav/Properties/AssemblyInfo.json
+++ b/src/Cogworks.Meganav/Properties/AssemblyInfo.json
@@ -4,7 +4,7 @@
   "company": "Cogworks",
   "product": "Umbraco Meganav",
   "copyright": "Copyright © 2017",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "informationalVersion": null,
-  "fileVersion": "1.0.1"
+  "fileVersion": "1.1.0"
 }

--- a/src/Cogworks.Meganav/PropertyEditors/MeganavPropertyEditor.cs
+++ b/src/Cogworks.Meganav/PropertyEditors/MeganavPropertyEditor.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Core.PropertyEditors;
+﻿using System.Collections.Generic;
+using Umbraco.Core.PropertyEditors;
 
 namespace Cogworks.Meganav.PropertyEditors
 {
@@ -14,6 +15,9 @@ namespace Cogworks.Meganav.PropertyEditors
         {
             [PreValueField("maxDepth", "Max Depth", "number")]
             public string MaxDepth { get; set; }
+
+            [PreValueField( "properties", "Properties", "~/App_Plugins/Meganav/Views/prevalues.html" )]
+            public IEnumerable<PreValueField> Properties { get; set; }
         }
     }
 }

--- a/src/Cogworks.Meganav/ValueConverters/MeganavValueConverter.cs
+++ b/src/Cogworks.Meganav/ValueConverters/MeganavValueConverter.cs
@@ -51,6 +51,12 @@ namespace Cogworks.Meganav.ValueConverters
                     item.Content = UmbracoContext.Current.ContentCache.GetById(item.Id);
                 }
 
+                // Extra properties default value
+                if ( item.Properties == null )
+                {
+                    item.Properties = new Dictionary<string, object>();
+                }
+
                 // process child items
                 if (item.Children.Any())
                 {

--- a/src/Cogworks.Meganav/Web/UI/App_Plugins/Meganav/Js/meganavPrevalue.controller.js
+++ b/src/Cogworks.Meganav/Web/UI/App_Plugins/Meganav/Js/meganavPrevalue.controller.js
@@ -1,0 +1,39 @@
+﻿function Prevalues($scope, meganavPreValueConfigService) {
+
+  // Setup Dialog Overlay
+  $scope.meganavSettingsOverlay = {
+    view: "views/propertyeditors/grid/dialogs/editconfig.html",
+    title: "Properties",
+    show: false,
+    config: $scope.model.value || [],
+
+    submit: function (model) {
+      $scope.model.value = model.config;
+      $scope.meganavSettingsOverlay.show = false;
+    },
+
+    close: function (oldModel) {
+      $scope.meganavSettingsOverlay.show = false;
+    }
+  };
+
+  $scope.editConfig = function (config) {
+    $scope.meganavSettingsOverlay.show = true;
+    meganavPreValueConfigService.config.settings = config;
+  };
+
+  $scope.removeConfigValue = function (collection, index) {
+    collection.splice(index, 1);
+  };
+}
+
+angular.module("umbraco").controller("Cogworks.Meganav.MeganavPrevalueController", Prevalues);
+
+
+app.service('meganavPreValueConfigService', function () {
+  var _config = {};
+
+  return {
+    config: _config
+  };
+});

--- a/src/Cogworks.Meganav/Web/UI/App_Plugins/Meganav/Views/editor.html
+++ b/src/Cogworks.Meganav/Web/UI/App_Plugins/Meganav/Views/editor.html
@@ -3,7 +3,7 @@
     <ng-form name="meganavEditorForm">
 
         <!-- meganav sortable tree -->
-        <div ui-tree data-max-depth="{{model.config.maxDepth}}">
+        <div ui-tree="treeOptions" data-max-depth="{{model.config.maxDepth}}">
 
             <ol ui-tree-nodes ng-model="items">
 

--- a/src/Cogworks.Meganav/Web/UI/App_Plugins/Meganav/Views/prevalues.html
+++ b/src/Cogworks.Meganav/Web/UI/App_Plugins/Meganav/Views/prevalues.html
@@ -1,0 +1,35 @@
+﻿<div ng-controller="Cogworks.Meganav.MeganavPrevalueController" class="umb-editor">
+
+    <ul class="unstyled list-icons umb-contentpicker" ui-sortable ng-model="model.value">
+
+      <li ng-repeat="configValue in model.value">
+        <i class="icon icon-navigation handle"></i>
+
+        <a href="#" prevent-default ng-click="removeConfigValue(model.value, $index)">
+          <i class="icon icon-delete red hover-show"></i>
+          <i class="icon-settings-alt-2 hover-hide"></i>
+          {{configValue.label}}
+        </a>
+      </li>
+
+    </ul>
+
+    <ul class="unstyled list-icons">
+
+      <li>
+        <i class="icon icon-add blue"></i>
+
+        <a href="#" ng-click="editConfig(model.config.settings)" prevent-default>
+          <localize key="general_edit" />
+        </a>
+      </li>
+
+    </ul>
+
+    <umb-overlay ng-if="meganavSettingsOverlay.show"
+      model="meganavSettingsOverlay"
+      view="meganavSettingsOverlay.view"
+      position="right">
+    </umb-overlay>
+
+</div>

--- a/src/Cogworks.Meganav/Web/UI/App_Plugins/Meganav/Views/settings.html
+++ b/src/Cogworks.Meganav/Web/UI/App_Plugins/Meganav/Views/settings.html
@@ -13,6 +13,7 @@
 
     </umb-control-group>
 
+
     <umb-control-group label="@content_nodeName">
 
         <p ng-if="target.name">
@@ -28,6 +29,7 @@
 
     </umb-control-group>
 
+
     <umb-control-group label="@content_target">
 
         <select class="umb-editor umb-dropdown" ng-model="target.target">
@@ -39,22 +41,25 @@
 
     </umb-control-group>
 
-    <umb-tree-search-box hide-search-callback="hideSearch"
-                         search-callback="onSearchResults"
-                         search-from-id="{{searchInfo.searchFromId}}"
-                         search-from-name="{{searchInfo.searchFromName}}"
-                         show-search="{{searchInfo.showSearch}}"
-                         section="{{section}}">
-    </umb-tree-search-box>
 
-    <br />
+    <umb-control-group label="Content">
 
-    <umb-tree-search-results ng-if="searchInfo.showSearch"
-                             results="searchInfo.results"
-                             select-result-callback="selectResult">
-    </umb-tree-search-results>
+      <umb-tree-search-box hide-search-callback="hideSearch"
+                           search-callback="onSearchResults"
+                           search-from-id="{{searchInfo.searchFromId}}"
+                           search-from-name="{{searchInfo.searchFromName}}"
+                           show-search="{{searchInfo.showSearch}}"
+                           section="{{section}}">
+      </umb-tree-search-box>
 
-    <div ng-hide="searchInfo.showSearch">
+      <br />
+
+      <umb-tree-search-results ng-if="searchInfo.showSearch"
+                               results="searchInfo.results"
+                               select-result-callback="selectResult">
+      </umb-tree-search-results>
+
+      <div ng-hide="searchInfo.showSearch">
 
         <umb-tree section="content"
                   hideheader="true"
@@ -64,6 +69,12 @@
                   enablecheckboxes="true">
         </umb-tree>
 
-    </div>
+      </div>
+
+    </umb-control-group>
+
+    <umb-property property="val" ng-repeat="val in model.properties">
+      <umb-property-editor model="val" is-pre-value="true"></umb-property-editor>
+    </umb-property>
 
 </div>

--- a/src/Cogworks.Meganav/Web/UI/App_Plugins/Meganav/package.manifest
+++ b/src/Cogworks.Meganav/Web/UI/App_Plugins/Meganav/package.manifest
@@ -2,6 +2,7 @@
   "javascript": [
     "~/App_Plugins/Meganav/js/meganav.controller.js",
     "~/App_Plugins/Meganav/js/meganavSettings.controller.js",
+    "~/App_Plugins/Meganav/js/meganavPrevalue.controller.js",
     "~/App_Plugins/Meganav/js/meganav.resource.js",
     "~/App_Plugins/Meganav/js/angular-ui-tree.js"
   ],


### PR DESCRIPTION
This patch adds support for adding custom properties, using the same techniques as found in the grid editor settings. This is heavily based on the original fork by @ArnoldV, updated to work with the latest changes in the dev branch, along with some added improvements (such as support for the ApplyTo property, allowing you to specify which depth your properties should appear).

This now adds the extra properties below the default ones. Whether or not this is merged, I'll be trying to continue supporting this functionality for future meganav updates. Hopefully someone else finds this useful.